### PR TITLE
Update brfs to 0.0.8 and allow anything reasonably close to it

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "browserify-shim": "~2.0.8"
   },
   "peerDependencies": {
-    "brfs": "0.0.6",
+    "brfs": "~0.0.8",
     "handlebars-runtime": "~1.0.12",
     "hbsfy": "~0.1.5"
   }


### PR DESCRIPTION
Got hung up because the brfs in my app was newer than the one atomify-js wanted. Seems to work on 0.0.8 too.
