### PR TITLE
Add support for extra transforms to be provided in options

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,9 @@ module.exports = function (opts, cb) {
   if (!opts.shim) opts.shim = {}
   var bundle = shim(browserify(), opts.shim)
   bundle.require(require.resolve(opts.entry), {entry: true})
-  bundle.transform(envify)
-  bundle.transform(hbsfy)
-  bundle.transform(brfs)
+  opts.transforms = [envify, hbsfy, brfs].concat(opts.transforms || [])
+  opts.transforms.forEach(function (transform) {
+    bundle.transform(transform)
+  })
   bundle.bundle({debug: opts.debug || false}, cb)
 }


### PR DESCRIPTION
I'm not sure if maybe you want to keep things small and opinionated, but I thought it could be handy to be able to specify additional transforms in the opts object. Things like different templating libraries, coffeeify, etc. come to mind.
