### PR TITLE
Make transforms actual dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,8 @@
   "license": "MIT",
   "dependencies": {
     "browserify": "~3.24.1",
-    "browserify-shim": "~2.0.8"
-  },
-  "peerDependencies": {
+    "browserify-shim": "~2.0.8",
     "brfs": "~0.0.9",
-    "handlebars-runtime": "~1.0.12",
     "hbsfy": "~1.3.1",
     "envify": "~1.0.1"
   }


### PR DESCRIPTION
Also removes `handlebars-runtime` as `hbsfy` now bundles the runtime itself.
