### PR TITLE
Add a way to set browserify options

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ You want to use node modules with handlebars tempaltes and inlined fs calls on t
 atomify-js takes an `opts` object and a `callback`.
 
 The `opts` object must contain an `entry` key that is the path to the entry file for atomify.
+You can pass any [browserify bundle options](https://github.com/substack/node-browserify#bbundleopts-cb) into the `opts` object as well.
 
 The `callback` will be called with an (optional) `error` as it's first argument and atomified `source`.
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,9 @@ var browserify = require('browserify')
   , brfs       = require('brfs')
 
 module.exports = function (opts, cb) {
-  if (!opts.shim) opts.shim = {}
+  opts = opts || {}
+  opts.shim = opts.shim || {}
+  opts.debug = opts.debug || false
   var bundle = shim(browserify(), opts.shim)
 
   bundle.require(require.resolve(opts.entry), {entry: true})
@@ -18,5 +20,5 @@ module.exports = function (opts, cb) {
     bundle.transform(transform)
   })
 
-  bundle.bundle({debug: opts.debug || false}, cb)
+  bundle.bundle(opts, cb)
 }


### PR DESCRIPTION
While in "dev" mode I wanted to set `insertGlobals` so that build times were faster (for us it cuts the build time in over half from 1000ms to 400ms). I didn't see anyway to set this from a glance so I added it by allowing atomify-js to accept a `browserify` option hash inside the normal option hash. Like this:

``` js
atomifyjs({
  entry: 'foo.js',
  browserify: { insertGlobals: true }
});
```
