### PR TITLE
support stream.

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ module.exports = function (opts, cb) {
   })
 
   if (opts.output) {
-    b.bundle(opts, writer(path.resolve(process.cwd(), opts.output), {debug: opts.debug}))
+    return b.bundle(opts, writer(path.resolve(process.cwd(), opts.output), {debug: opts.debug}))
   } else {
     return b.bundle(opts, cb)
   }


### PR DESCRIPTION
If opts.output and cb are undefined, b.bundle can return a stream.
