### PR TITLE
fix uncaught exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ In its default form, atomify-js takes an `opts` object and a `callback` function
 
 **opts.entry** or **opts.entries** - Path or paths that will be provided to Browserify as entry points. For convenience, you may simply provide a string or array of strings in place of the `opts` object, which will be treated as the `entry` or `entries` property, respectively. Paths will be resolved relative to `process.cwd()`.
 
-**opts.output** - If you simply want your bundle written out to a file, provide the path in this property. Note that your `callback` will NOT be called if this property is present. Path will be resolved relative to `process.cwd()`.
+**opts.output** - If you simply want your bundle written out to a file, provide the path in this property. Path will be resolved relative to `process.cwd()`.
 
 **opts.debug** - Passed to Browserify to generate source maps if `true`. Also provides additional CLI output, if applicable.
 

--- a/index.js
+++ b/index.js
@@ -33,8 +33,9 @@ var ctor = module.exports = function (opts, cb) {
     if (typeof cb === 'function') {
       var _cb = cb
       cb = function (err, src) {
-        writeFile(err, src)
-        _cb(err, src)
+        if (err) return _cb(err)
+        writeFile(null, src)
+        _cb(null, src)
       }
     } else {
       cb = writeFile


### PR DESCRIPTION
This prevents atomify from crashing when there's a syntax error in your
scripts.
