### PR TITLE
Revert watchify to old version for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "reactify": "^0.15.2",
     "resrcify": "^1.1.0",
     "stream-buffers": "^1.1.0",
-    "watchify": "^2.1.1",
+    "watchify": "^0.10.2",
     "write-to-path": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The latest version of watchify has a significant API change, which requires a bundle to be passed in as the first argument. This will require some refactoring, as before watchify produced a bundle instead.

Reverting for now and will try to refactor if I get a chance!
