### PR TITLE
Add opts.cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ node_modules
 .idea
 test/fixtures/assets/output/*
 test/fixtures/watch/output/*
+test/fixtures/cache/output/*
 *bundle-output*
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ atomify-js is a tool that makes it easy to create small, atomic modules of clien
     - [opts.debug](#optsdebug)
     - [opts.minify](#optsminify)
     - [opts.watch](#optswatch)
+    - [opts.cache](#optscache)
     - [opts.transforms](#optstransforms)
     - [opts.globalTransforms](#optsglobaltransforms)
     - [opts.require](#optsrequire)
@@ -111,6 +112,13 @@ If `true`, minifies source code and sets debug to true. If object, passed as opt
 
 #### opts.watch
 If `true`, [watchify](https://github.com/substack/watchify) will be used to create a file watcher and speed up subsequent builds.
+
+#### opts.cache
+If truthy, will use [browserify-incremental](https://github.com/jsdf/browserify-incremental) to cache the result of a build. This can give you dramatically faster build times if you're not using `opts.watch`.
+
+If `opts.cache` is a string, it will be used as the file path to save the cache file to.
+
+_NOTE_: `opts.cache` and `opts.watch` are incompatible. An error will be thrown if you set both.
 
 #### opts.transforms
 Provide your own transforms that will be added to the defaults listed above.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "brfs": "^1.2.0",
     "browserify": "^9.0.3",
+    "browserify-incremental": "^1.5.0",
     "ejsify": "^1.0.0",
     "envify": "^3.2.0",
     "factor-bundle": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "tape test/*.js | tspec",
-    "tdd": "nodemon -x npm -i node_modules/ -i test/fixtures/output/ -i test/fixtures/watch/output/* -- test"
+    "tdd": "nodemon -x npm -i node_modules/ -i test/fixtures/output/ -i test/fixtures/watch/output/ -i test/fixtures/cache/output/ -- test"
   },
   "repository": {
     "type": "git",

--- a/test/cache.js
+++ b/test/cache.js
@@ -1,0 +1,69 @@
+'use strict'
+
+var test = require('tape')
+  , lib = require('../index.js')
+  , path = require('path')
+  , fs = require('fs')
+  , entryPath = path.join(__dirname, 'fixtures', 'cache')
+  , outputPath = path.join(entryPath, 'output')
+  , changerPath = path.join(outputPath, 'changer.js')
+  , mkdirp = require('mkdirp')
+  , cachePath = path.join(outputPath, 'cache.json')
+  , setup = function setup(value){
+    var file = 'module.exports = ' + value || Date.now()
+
+    mkdirp.sync(outputPath)
+    fs.writeFileSync(changerPath, file)
+  }
+
+test('opts.cache', function(t){
+  var parseTime = function parseTime(logMsg){
+    return parseFloat(logMsg.replace(/.*?\(([0-9\.]{1,}) seconds\)/, '$1'))
+  }
+
+  setup()
+
+  t.plan(5)
+
+  t.throws(
+    lib.bind(null, {watch: true, cache: true})
+    , 'should throw if opts.watch is also set'
+  )
+
+  lib.emitter.once('browserify', function (b){
+    b.once('log', function(msg){
+      var initialTime = parseTime(msg)
+
+      t.ok(
+        msg
+        , 'compiles once'
+      )
+
+      b.bundle()
+      b.once('log', function(msg2){
+        var secondTime = parseTime(msg2)
+
+        // wait for the second callback because some fs are slow. (linux)
+        t.ok(
+          fs.existsSync(cachePath)
+          , 'writes the cache file'
+        )
+
+        // cleanup
+        fs.unlinkSync(cachePath)
+
+        t.ok(
+          msg2
+          , 'compiles a second time'
+        )
+
+        t.ok(
+          secondTime < initialTime
+          , 'the second compile is faster'
+        )
+      })
+    })
+  })
+
+  lib({cache: cachePath, entry: path.join(entryPath, 'index.js')})
+})

--- a/test/fixtures/cache/index.js
+++ b/test/fixtures/cache/index.js
@@ -1,0 +1,2 @@
+var dep = require('../entry/dep-1.js')
+  , changer = require('./output/changer.js')

--- a/test/watch.js
+++ b/test/watch.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 var test = require('tape')
   , lib = require('../index.js')


### PR DESCRIPTION
Significantly faster builds are now possible via browserify-incremental.

Adds a very simple test that has a 5x speed increase.