### PR TITLE
Revert to browserify v7.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "brfs": "^1.4.0",
-    "browserify": "^9.0.3",
+    "browserify": "^7.1.0",
     "browserify-incremental": "^1.5.0",
     "ejsify": "^1.0.0",
     "envify": "^3.4.0",


### PR DESCRIPTION
The logic for deduping in the v8+ code has proven to be very bug-prone.

e.g. https://github.com/substack/node-browserify/issues/1176
https://github.com/substack/node-browserify/issues/1173
https://github.com/substack/node-browserify/issues/1150

and specifically: https://github.com/substack/node-browserify/issues/1131#issuecomment-76392918

Reverting to v7 seems to fix many of these issues. The changes between
v7.1.0 and v9.0.3 (latest as of this commit) are trivial and do not
affect atomify-js functionality. This reversion should allow atomify-js
to work better with complex while costing very little (maybe nothing)
lost browserify functionality.